### PR TITLE
Make The Controller And Form Name Available For Field Construction

### DIFF
--- a/code/MultiForm.php
+++ b/code/MultiForm.php
@@ -403,8 +403,11 @@ abstract class MultiForm extends Form {
 			return false;
 		}
 
-		// custom validation (use MultiFormStep->getValidator() for built-in functionality)
+		// Perform custom step validation (use MultiFormStep->getValidator() for
+		// built-in functionality). The data needs to be manually saved on error
+		// so the form is re-populated.
 		if(!$this->getCurrentStep()->validateStep($data, $form)) {
+			Session::set("FormInfo.{$form->FormName()}.data", $form->getData());
 			Director::redirectBack();
 			return false;
 		}


### PR DESCRIPTION
Currently the MultiForm constructor generates the fields from the current step, then passes it to the parent constructor which sets the controller and name properties on the form instance.

Since it is often useful to pull data from the parent controller in individual MultiFormStep field methods, I updated it to manually set the controller and name before calling getFields().
