### PR TITLE
Add Explicity Display Link Method

### DIFF
--- a/code/MultiForm.php
+++ b/code/MultiForm.php
@@ -75,7 +75,12 @@ abstract class MultiForm extends Form {
 	public static $actions_exempt_from_validation = array(
 		'action_prev'
 	);
-	
+
+	/**
+	 * @var string
+	 */
+	protected $displayLink;
+
 	/**
 	 * Start the MultiForm instance.
 	 *
@@ -505,6 +510,29 @@ abstract class MultiForm extends Form {
 		$action .= "MultiFormSessionID={$this->session->Hash}";
 		
 		return $action;
+	}
+
+	/**
+	 * Returns the link to the page where the form is displayed. The user is
+	 * redirected to this link with a session param after each step is
+	 * submitted.
+	 *
+	 * @return string
+	 */
+	public function getDisplayLink() {
+		return $this->displayLink ? $this->displayLink : Controller::curr()->Link();
+	}
+
+	/**
+	 * Set the link to the page on which the form is displayed.
+	 *
+	 * The link defaults to the controllers current link. However if the form
+	 * is displayed inside an action the display link must be explicitly set.
+	 *
+	 * @param string $link
+	 */
+	public function setDisplayLink($link) {
+		$this->displayLink = $link;
 	}
 
 	/**

--- a/code/MultiFormStep.php
+++ b/code/MultiFormStep.php
@@ -126,7 +126,7 @@ class MultiFormStep extends DataObject {
 	 * @return string Relative URL to this step
 	 */
 	public function Link() {
-		return Controller::curr()->Link() . '?MultiFormSessionID=' . $this->Session()->Hash;
+		return Controller::join_links($this->form->getDisplayLink(), "?MultiFormSessionID={$this->Session()->Hash}");
 	}
 
 	/**


### PR DESCRIPTION
Currently the user is redirected back to the current controller link after each step, with the expectation that it will display the form again. However, if the multiform is displayed inside a controller action this obviously won't work. I've added a method so you can explicitly set the link where the form is displayed so this less common case can be catered for.
