### PR TITLE
MINOR: fixing completed class for current step

### DIFF
--- a/code/model/MultiForm.php
+++ b/code/model/MultiForm.php
@@ -594,12 +594,15 @@ abstract class MultiForm extends Form {
 
 		$firstStep = DataObject::get_one(static::$start_step, "\"SessionID\" = {$this->session->ID}");
 		$firstStep->LinkingMode = ($firstStep->ID == $this->getCurrentStep()->ID) ? 'current' : 'link';
-		$firstStep->addExtraClass('completed');
 		$firstStep->setForm($this);
 		$stepsFound->push($firstStep);
 
 		// mark the further steps as non-completed if the first step is the current
-		if ($firstStep->ID == $this->getCurrentStep()->ID) $this->currentStepHasBeenFound = true;
+		if ($firstStep->ID == $this->getCurrentStep()->ID) {
+			$this->currentStepHasBeenFound = true;
+		} else {
+			$firstStep->addExtraClass('completed');
+		}
 
 		$this->getAllStepsRecursive($firstStep, $stepsFound);
 


### PR DESCRIPTION
Hello @tractorcow 

I discovered a bug in my own code. Shame on me. For the first step the "completed" class would have been added even when the first step wasn't completed (= being on the first step).

Spek