### PR TITLE
MINOR: allowing to load submission from other steps easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,49 @@ This new method you create would then become available in the progress indicator
 template.
 
 
-### 7. Finishing it up
+### 7. Loading values from other steps
+
+There are several use cases were you want to pre-populate a value based
+based on the submission value of another step. There are two methods supporting this:
+
+* `getValueFromOtherStep()` load any submitted value from another step from the session
+* `copyValueFromOtherStep()` saves you the repeated work of adding the same lines of code again and again.
+
+Here is an example of how to populate the email address from step 1 in step2 :
+
+	:::php
+	<?php
+
+	class Step1 extends MultiFormStep
+	{
+		public static $next_steps = 'Step2';
+
+		public function getFields() {
+			return new FieldList(
+				new EmailField('Email', 'Your email')
+			);
+		}
+	}
+
+	class Step2 extends MultiFormStep
+	{
+		public static $next_steps = 'Step3';
+
+		public function getFields() {
+			$fields = new FieldList(
+				new EmailField('Email', 'E-mail'),
+				new EmailField('Email2', 'Verify E-Mail')
+			);
+
+			// set the email field to the input from Step 1
+			$this->copyValueFromOtherStep($fields, 'Step1', 'Email');
+
+			return $fields;
+		}
+	}
+
+
+### 8. Finishing it up
 
 Now that we've got a structure set up to collect form data along each step, and
 progress through successfully, we need to customise what happens at the end of 
@@ -394,7 +436,7 @@ Here is an example of what we could do here:
 	}
 
 
-#### 8. Organisation data model
+#### 9. Organisation data model
 
 The class Organisation is mentioned in the above example but doesn't exist at 
 the moment (unlike the existing Member() class which looks after the member 

--- a/code/model/MultiFormStep.php
+++ b/code/model/MultiFormStep.php
@@ -421,8 +421,6 @@ class MultiFormStep extends DataObject {
 	/**
 	 * Returns the submitted value, if any, of any steps.
 	 *
-	 * @todo  to be removed once https://github.com/silverstripe/silverstripe-multiform/pull/55 is merged in
-	 *
 	 * @param string $fromStep
 	 * @param string $key
 	 * @return mixed
@@ -433,7 +431,7 @@ class MultiFormStep extends DataObject {
 			$steps = MultiFormStep::get()->filter('SessionID', $this->form->session->ID);
 
 			if($steps) foreach($steps as $step) {
-				$this->cache['steps_' . $step] = $step->loadData();
+				$this->cache['steps_' . $step->ClassName] = $step->loadData();
 			}
 		}
 

--- a/code/model/MultiFormStep.php
+++ b/code/model/MultiFormStep.php
@@ -80,6 +80,13 @@ class MultiFormStep extends DataObject {
 	protected $extraClasses = array();
 
 	/**
+	 * Temporary cache to increase the performance for repeated look ups.
+	 *
+	 * @var array $cache
+	 */
+	protected $cache = array();
+
+	/**
 	 * Form fields to be rendered with this step.
 	 * (Form object is created in {@link MultiForm}.
 	 *
@@ -409,5 +416,44 @@ class MultiFormStep extends DataObject {
 	 */
 	public function getExtraClasses() {
 		return join(' ', array_keys($this->extraClasses));
+	}
+
+	/**
+	 * Returns the submitted value, if any, of any steps.
+	 *
+	 * @todo  to be removed once https://github.com/silverstripe/silverstripe-multiform/pull/55 is merged in
+	 *
+	 * @param string $fromStep
+	 * @param string $key
+	 * @return mixed
+	 */
+	public function getValueFromOtherStep($fromStep, $key) {
+		// load the steps in the cache, if this one doesn't exist
+		if (!array_key_exists('steps_' . $fromStep, $this->cache)) {
+			$steps = MultiFormStep::get()->filter('SessionID', $this->form->session->ID);
+
+			if($steps) foreach($steps as $step) {
+				$this->cache['steps_' . $step] = $step->loadData();
+			}
+		}
+
+		// check both as PHP isn't recursive
+		return (isset($this->cache['steps_' . $fromStep]) && isset($this->cache['steps_' . $fromStep][$key])) ?
+			$this->cache['steps_' . $fromStep][$key] : null;
+	}
+
+	/**
+	 * allows to get a value from another step copied over
+	 *
+	 * @param FieldList $fields
+	 * @param string    $formStep
+	 * @param string    $fieldName
+	 * @param string    $fieldNameTarget (optional)
+	 */
+	public function copyValueFromOtherStep(FieldList $fields, $formStep, $fieldName, $fieldNameTarget = null) {
+		// if a target field isn't defined use the same fieldname
+		if (!$fieldNameTarget) $fieldNameTarget = $fieldName;
+
+		$fields->fieldByName($fieldNameTarget)->setValue($this->getValueFromOtherStep($formStep, $fieldName));
 	}
 }

--- a/code/model/MultiFormStep.php
+++ b/code/model/MultiFormStep.php
@@ -421,7 +421,7 @@ class MultiFormStep extends DataObject {
 	/**
 	 * Returns the submitted value, if any, of any steps.
 	 *
-	 * @param string $fromStep
+	 * @param string $fromStep (classname)
 	 * @param string $key
 	 * @return mixed
 	 */


### PR DESCRIPTION
The two methods I added allow to set values from other (previous or next steps after going back) to fields as defaults. For cases where the form would be build differently in some cases. e.g. don't show a section which isn't relevant the *getValueFromOtherStep* method is interesting