### PR TITLE
Ensure compatibility with SS 3.7 & PHP 7.2

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,2 +1,7 @@
 <?php
 
+// Ensure compatibility with PHP 7.2 ("object" is a reserved word),
+// with SilverStripe 3.6 (using Object) and SilverStripe 3.7 (using SS_Object)
+if (!class_exists('SS_Object')) {
+    class_alias('Object', 'SS_Object');
+}

--- a/code/model/MultiForm.php
+++ b/code/model/MultiForm.php
@@ -221,7 +221,7 @@ abstract class MultiForm extends Form {
 
 		// Always fall back to creating a new step (in case the session or request data is invalid)
 		if(!$currentStep || !$currentStep->ID) {
-			$currentStep = Object::create($startStepClass);
+			$currentStep = SS_Object::create($startStepClass);
 			$currentStep->SessionID = $this->session->ID;
 			$currentStep->write();
 			$this->session->CurrentStepID = $currentStep->ID;
@@ -483,7 +483,7 @@ abstract class MultiForm extends Form {
 
 		// Determine whether we can use a step already in the DB, or have to create a new one
 		if(!$nextStep = DataObject::get_one($nextStepClass, "\"SessionID\" = {$this->session->ID}")) {
-			$nextStep = Object::create($nextStepClass);
+			$nextStep = SS_Object::create($nextStepClass);
 			$nextStep->SessionID = $this->session->ID;
 			$nextStep->write();
 		}


### PR DESCRIPTION
This fixes the SS 3.7+ & PHP 7.2 compatibility, effectively renaming calls to Object:: to SS_Object:: and aliasing SS_Object to Object for backwards compatibility (older versions of SilverStripe) [as described here](https://docs.silverstripe.org/en/3/changelogs/3.7.0/#for-module-authors)