### PR TITLE
Fix get current step

### DIFF
--- a/src/Forms/MultiForm.php
+++ b/src/Forms/MultiForm.php
@@ -229,14 +229,14 @@ abstract class MultiForm extends Form
         $currentStep = null;
         $StepID = $this->controller->getRequest()->getVar('StepID');
         if (isset($StepID)) {
-            $currentStep = DataObject::get_one(
-                MultiFormStep::class,
-                [
-                    'SessionID' => $this->session->ID,
-                    'ID' => $StepID
-                ]
-            );
-        } elseif ($this->session->CurrentStepID) {
+            $currentStep = MultiFormStep::get()->filter([
+                'SessionID' => $this->session->ID,
+                'ID' => $StepID
+            ])->first();
+        }
+
+        // if current step doesn't exist and no session current step then get the current step
+        if (!$currentStep && $this->session->CurrentStepID) {
             $currentStep = $this->session->CurrentStep();
         }
 


### PR DESCRIPTION
If you have completed a multiform and you navigate back, sometimes the step ID in the query string relates to a session that no longer exists. This fix will prevent duplicate steps being created in the database.