### PR TITLE
BUGFIX getValueFromOtherStep() calls protected MultiForm::$session

### DIFF
--- a/src/Models/MultiFormStep.php
+++ b/src/Models/MultiFormStep.php
@@ -475,7 +475,7 @@ class MultiFormStep extends DataObject
     {
         // load the steps in the cache, if this one doesn't exist
         if (!array_key_exists('steps_' . $fromStep, $this->step_data_cache)) {
-            $steps = self::get()->filter('SessionID', $this->form->session->ID);
+            $steps = MultiFormStep::get()->filter('SessionID', $this->form->getMultiFormSession()->ID);
 
             if ($steps) {
                 foreach ($steps as $step) {


### PR DESCRIPTION
Use the provided `MultiForm::getMultiFormSession()` method to get the proper result.

resolves #83 
resolves #85 